### PR TITLE
fix: TypeScript errors in build

### DIFF
--- a/src/components/HeroV2.astro
+++ b/src/components/HeroV2.astro
@@ -171,7 +171,7 @@ import { WHATSAPP_URL } from "@utils/const";
   const revealOnScroll = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
       if (entry.isIntersecting) {
-        entry.target.style.animationPlayState = 'running';
+        (entry.target as HTMLElement).style.animationPlayState = 'running';
       }
     });
   });

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -30,7 +30,7 @@ const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
     .map(
       (project) => `
   <url>
-    <loc>https://codeamus.dev/projects/${project.slug}</loc>
+    <loc>https://codeamus.dev/projects/${project.id}</loc>
     <priority>0.8</priority>
     <changefreq>monthly</changefreq>
     <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>


### PR DESCRIPTION
- HeroV2.astro: Cast entry.target to HTMLElement to fix style property error
- sitemap.xml.ts: Use project.id instead of project.slug for content collection URLs